### PR TITLE
Added profile for deployment to payara server running in docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.host>192.168.99.100</docker.host>
         <couchbase.port>8091</couchbase.port>
+        <payara.home>${glassfish.home}</payara.home>
+        <payara.domain>payaradomain</payara.domain>
+        <payara.adminPort>4848</payara.adminPort>
+        <payara.username>admin</payara.username>
+        <payara.password>glassfish</payara.password>
     </properties>
 
     <dependencies>
@@ -153,6 +158,43 @@
                                         <version>${project.version}</version>
                                         <type>war</type>
                                     </appArtifact>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>payara</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.glassfish.maven.plugin</groupId>
+                        <artifactId>maven-glassfish-plugin</artifactId>
+                        <version>2.1</version>
+                        <executions>
+                            <execution>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                </goals>
+                                <configuration>
+                                    <echo>true</echo>
+                                    <user>${payara.username}</user>
+                                    <adminPassword>${payara.password}</adminPassword>
+                                    <glassfishDirectory>${payara.home}</glassfishDirectory>
+                                    <domain>
+                                        <name>${payara.domain}</name>
+                                        <adminPort>${payara.adminPort}</adminPort>
+                                        <host>${payara.hostname}</host>
+                                    </domain>
+                                    <components> 
+                                        <component> 
+                                            <name>${project.artifactId}</name> 
+                                            <artifact>${project.build.directory}/${project.build.finalName}.war</artifact> 
+                                        </component> 
+                                    </components>
                                 </configuration>
                             </execution>
                         </executions>

--- a/src/main/docker/images/payara/docker-compose.yml
+++ b/src/main/docker/images/payara/docker-compose.yml
@@ -1,0 +1,13 @@
+mycouchbase:
+  image: couchbase/server
+  ports:
+    - 8091:8091
+    - 8092:8092 
+    - 8093:8093 
+    - 11210:11210
+mypayara:
+  image: payaradocker/payaraserver:4.1.1.154
+  command: /bin/bash -c './asadmin start-domain payaradomain && while kill -0 $(cat ../domains/payaradomain/config/pid); do sleep 0.5; done'
+  ports:
+    - 8080:8080
+    - 4848:4848


### PR DESCRIPTION
The profile configures standard maven glassfish plugin to deploy to a payara server over tcp.  The plugin uses asadmin command and requires local installation of either glassfish or payara. Path to this installation needs to be passed via payara.home maven property. 
Example of maven deployment command:

mvn install -Ppayara -Dpayara.hostname=$payaraIp -Dpayara.home=/path/to/payara

Additionally, a docker-compose file for couchbase and payara is included in src/main/docker/images/payara/docker-compose.yml.
If executed via "docker-compose up" before, it can be directly used as a deployment target for the above maven deployment command (provided that you can find out IP of the network interface inside the payara docker instance).
