### PR TITLE
Payara profile for deployment using cargo maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.host>192.168.99.100</docker.host>
         <couchbase.port>8091</couchbase.port>
+        <payara.home>${glassfish.home}</payara.home>
+        <payara.domain>payaradomain</payara.domain>
+        <payara.adminPort>4848</payara.adminPort>
+        <payara.username>admin</payara.username>
+        <payara.password>glassfish</payara.password>
     </properties>
 
     <dependencies>
@@ -153,6 +158,43 @@
                                         <version>${project.version}</version>
                                         <type>war</type>
                                     </appArtifact>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>payara</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.glassfish.maven.plugin</groupId>
+                        <artifactId>maven-glassfish-plugin</artifactId>
+                        <version>2.1</version>
+                        <executions>
+                            <execution>
+                                <phase>install</phase>
+                                <goals>
+                                    <goal>deploy</goal>
+                                </goals>
+                                <configuration>
+                                    <echo>true</echo>
+                                    <user>${payara.username}</user>
+                                    <adminPassword>${payara.password}</adminPassword>
+                                    <glassfishDirectory>${payara.home}</glassfishDirectory>
+                                    <domain>
+                                        <name>${payara.domain}</name>
+                                        <adminPort>${payara.adminPort}</adminPort>
+                                        <host>${payara.hostname}</host>
+                                    </domain>
+                                    <components> 
+                                        <component> 
+                                            <name>${project.artifactId}</name> 
+                                            <artifact>${project.build.directory}/${project.build.finalName}.war</artifact> 
+                                        </component> 
+                                    </components>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -181,14 +181,30 @@
                                     <goal>redeploy</goal>
                                 </goals>
                                 <configuration>
-                                    <containerId>glassfish4x</containerId>
-                                    <cargo.remote.username>${payara.username}</cargo.remote.username>
-                                    <cargo.remote.password>${payara.password}</cargo.remote.password>
-                                    <cargo.glassfish.admin.port>${payara.adminPort}</cargo.glassfish.admin.port>
-                                    <cargo.hostname>${payara.hostname}</cargo.hostname>
+                                    <container>
+                                        <containerId>glassfish4x</containerId>
+                                        <type>remote</type>
+                                    </container>
+                                    <configuration>
+                                        <type>runtime</type>
+                                        <properties>
+                                            <cargo.remote.username>${payara.username}</cargo.remote.username>
+                                            <cargo.remote.password>${payara.password}</cargo.remote.password>
+                                            <cargo.glassfish.admin.port>${payara.adminPort}</cargo.glassfish.admin.port>
+                                            <cargo.hostname>${payara.hostname}</cargo.hostname>
+                                        </properties>
+                                    </configuration>
                                 </configuration>
                             </execution>
                         </executions>
+                        <!-- provides JSR88 client API to deploy on Glassfish and Payara -->
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.glassfish.main.deployment</groupId>
+                                <artifactId>deployment-client</artifactId>
+                                <version>4.1.1</version>
+                            </dependency>            
+                        </dependencies>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.host>192.168.99.100</docker.host>
         <couchbase.port>8091</couchbase.port>
-        <payara.home>${glassfish.home}</payara.home>
-        <payara.domain>payaradomain</payara.domain>
         <payara.adminPort>4848</payara.adminPort>
         <payara.username>admin</payara.username>
         <payara.password>glassfish</payara.password>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <payara.adminPort>4848</payara.adminPort>
         <payara.username>admin</payara.username>
         <payara.password>glassfish</payara.password>
+        <payara.hostname>localhost</payara.hostname>
     </properties>
 
     <dependencies>
@@ -170,31 +171,22 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.glassfish.maven.plugin</groupId>
-                        <artifactId>maven-glassfish-plugin</artifactId>
-                        <version>2.1</version>
+                        <groupId>org.codehaus.cargo</groupId>
+                        <artifactId>cargo-maven2-plugin</artifactId>
+                        <version>1.4.17</version>
                         <executions>
                             <execution>
                                 <phase>install</phase>
                                 <goals>
-                                    <goal>deploy</goal>
+                                    <goal>redeploy</goal>
                                 </goals>
                                 <configuration>
-                                    <echo>true</echo>
-                                    <user>${payara.username}</user>
-                                    <adminPassword>${payara.password}</adminPassword>
-                                    <glassfishDirectory>${payara.home}</glassfishDirectory>
-                                    <domain>
-                                        <name>${payara.domain}</name>
-                                        <adminPort>${payara.adminPort}</adminPort>
-                                        <host>${payara.hostname}</host>
-                                    </domain>
-                                    <components> 
-                                        <component> 
-                                            <name>${project.artifactId}</name> 
-                                            <artifact>${project.build.directory}/${project.build.finalName}.war</artifact> 
-                                        </component> 
-                                    </components>
+                                    <containerId>glassfish4x</containerId>
+                                    <cargo.remote.username>${payara.username}</cargo.remote.username>
+                                    <cargo.remote.password>${payara.password}</cargo.remote.password>
+                                    <cargo.glassfish.domain.name>${payara.domain}</cargo.glassfish.domain.name>
+                                    <cargo.glassfish.admin.port>${payara.adminPort}</cargo.glassfish.admin.port>
+                                    <cargo.hostname>${payara.hostname}</cargo.hostname>
                                 </configuration>
                             </execution>
                         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,6 @@
                                     <containerId>glassfish4x</containerId>
                                     <cargo.remote.username>${payara.username}</cargo.remote.username>
                                     <cargo.remote.password>${payara.password}</cargo.remote.password>
-                                    <cargo.glassfish.domain.name>${payara.domain}</cargo.glassfish.domain.name>
                                     <cargo.glassfish.admin.port>${payara.adminPort}</cargo.glassfish.admin.port>
                                     <cargo.hostname>${payara.hostname}</cargo.hostname>
                                 </configuration>

--- a/readme.adoc
+++ b/readme.adoc
@@ -1,6 +1,6 @@
 = Couchbase and Java EE
 
-This workspace will show how to query a Couchbase bucket using simple Java EE application deployed on WildFly.
+This workspace will show how to query a Couchbase bucket using simple Java EE application deployed on WildFly. Alternative configuration is also provided to deploy on Payara/GlassFish.
 
 == How to run?
 
@@ -28,7 +28,10 @@ To see how to connect Docker to this machine, run: docker-machine env couchbase-
 eval $(docker-machine env couchbase-javaee)
 ```
 +
-. Use Docker Compose file from https://github.com/arun-gupta/docker-images/blob/master/wildfly-couchbase-javaee7/docker-compose.yml and start the application environment as:
+. Start the application environment using Docker Compose file:
+  To deploy on WildFly::: https://github.com/arun-gupta/docker-images/blob/master/wildfly-couchbase-javaee7/docker-compose.yml
+  To deploy on Payara/GlassFish::: https://github.com/OndrejM/couchbase-javaee/blob/payara-profile/src/main/docker/images/payara/docker-compose.yml
+  * Start the application environment using Docker Compose file:
 +
 ```console
 docker-compose --x-networking up -d
@@ -241,6 +244,8 @@ mvn install -Pcouchbase -Ddocker.host=$(docker-machine ip couchbase-javaee)
 
 === Deploy Application
 
+==== Deploy to WildFly
+
 ```console
 mvn install -Pwildfly -Dwildfly.hostname=$(docker-machine ip couchbase-javaee) -Dwildfly.username=admin -Dwildfly.password=Admin#007
 [INFO] Scanning for projects...
@@ -322,6 +327,10 @@ INFO: JBoss Remoting version 4.0.9.Final
 [INFO] Final Memory: 20M/374M
 [INFO] ------------------------------------------------------------------------
 ```
+
+==== Deploy to Payara/GlassFish
+```console
+mvn install -Ppayara -Dpayara.hostname=$(docker-machine ip couchbase-javaee) -Dpayara.username=admin -Dpayara.password=glassfish
 
 === Access Application
 

--- a/src/main/docker/images/payara/docker-compose.yml
+++ b/src/main/docker/images/payara/docker-compose.yml
@@ -1,0 +1,13 @@
+mycouchbase:
+  image: couchbase/server
+  ports:
+    - 8091:8091
+    - 8092:8092 
+    - 8093:8093 
+    - 11210:11210
+mypayara:
+  image: payaradocker/payaraserver:4.1.1.154
+  command: /bin/bash -c './asadmin start-domain payaradomain && while kill -0 $(cat ../domains/payaradomain/config/pid); do sleep 0.5; done'
+  ports:
+    - 8080:8080
+    - 4848:4848


### PR DESCRIPTION
Added new payara maven profile to deploy to remote Payara server running in Docker.  Deployment profile uses cargo maven plugin with glassfish connector, which uses JSR88 deployment mechanism available in deployment-client artefact.

Fixes https://github.com/arun-gupta/couchbase-javaee/issues/7
